### PR TITLE
【パフォーマンス】不要なディープコピーの改善 (#23)

### DIFF
--- a/src/ai/badMoveAnalyzer.ts
+++ b/src/ai/badMoveAnalyzer.ts
@@ -1,3 +1,4 @@
+import { getAdjacentToCorner, getAllCorners, isCorner } from '../game/boardUtils';
 import { getAllValidMoves, getValidMove, makeMove } from '../game/rules';
 import type { Board, Player, Position } from '../game/types';
 import { evaluateBoard } from './evaluation';
@@ -31,43 +32,12 @@ export interface DetailedBadMoveAnalysis {
   bestMoveEvaluationChange: number;
 }
 
-const isCorner = (pos: Position): boolean => {
-  return (pos.row === 0 || pos.row === 7) && (pos.col === 0 || pos.col === 7);
-};
-
-// const _isEdge = (pos: Position): boolean => {
-//   return pos.row === 0 || pos.row === 7 || pos.col === 0 || pos.col === 7;
-// };
-
-const getAdjacentToCorner = (corner: Position): Position[] => {
-  const adjacent: Position[] = [];
-  const { row, col } = corner;
-
-  // 角の隣接マス（X-square と C-square）
-  if (row === 0 && col === 0) {
-    adjacent.push({ row: 0, col: 1 }, { row: 1, col: 0 }, { row: 1, col: 1 });
-  } else if (row === 0 && col === 7) {
-    adjacent.push({ row: 0, col: 6 }, { row: 1, col: 7 }, { row: 1, col: 6 });
-  } else if (row === 7 && col === 0) {
-    adjacent.push({ row: 7, col: 1 }, { row: 6, col: 0 }, { row: 6, col: 1 });
-  } else if (row === 7 && col === 7) {
-    adjacent.push({ row: 7, col: 6 }, { row: 6, col: 7 }, { row: 6, col: 6 });
-  }
-
-  return adjacent;
-};
-
 const analyzeCornerVulnerability = (
   board: Board,
   move: Position,
   player: Player
 ): BadMoveImpact | null => {
-  const corners: Position[] = [
-    { row: 0, col: 0 },
-    { row: 0, col: 7 },
-    { row: 7, col: 0 },
-    { row: 7, col: 7 },
-  ];
+  const corners = getAllCorners();
 
   for (const corner of corners) {
     // 角が空いている場合

--- a/src/ai/boardEvaluationExplainer.ts
+++ b/src/ai/boardEvaluationExplainer.ts
@@ -1,8 +1,15 @@
+import {
+  copyBoard,
+  getAllCorners,
+  isCorner,
+  isCSquare,
+  isEdge,
+  isXSquare,
+} from '../game/boardUtils';
 import { BOARD_SIZE } from '../game/constants';
 import { getAllValidMoves, getOpponent } from '../game/rules';
 import type { Board, Player, Position } from '../game/types';
 import { evaluateStableDiscs } from './evaluation';
-import { isCorner, isCSquare, isEdge, isXSquare } from './evaluationReasons';
 
 export interface MobilityAnalysis {
   playerMoves: number;
@@ -108,12 +115,7 @@ const analyzeStrongPositions = (board: Board, player: Player): StrongPositions =
   const stableDiscs: Position[] = [];
 
   // 角の確認
-  const cornerPositions = [
-    { row: 0, col: 0 },
-    { row: 0, col: BOARD_SIZE - 1 },
-    { row: BOARD_SIZE - 1, col: 0 },
-    { row: BOARD_SIZE - 1, col: BOARD_SIZE - 1 },
-  ];
+  const cornerPositions = getAllCorners();
 
   for (const pos of cornerPositions) {
     if (board[pos.row][pos.col] === player) {
@@ -175,12 +177,7 @@ const analyzeStrongPositions = (board: Board, player: Player): StrongPositions =
 // 角から連続している石は確定石
 const isStableFromCorner = (board: Board, pos: Position, player: Player): boolean => {
   // 簡略化された確定石判定（角から連続している辺の石）
-  const corners = [
-    { row: 0, col: 0 },
-    { row: 0, col: BOARD_SIZE - 1 },
-    { row: BOARD_SIZE - 1, col: 0 },
-    { row: BOARD_SIZE - 1, col: BOARD_SIZE - 1 },
-  ];
+  const corners = getAllCorners();
 
   for (const corner of corners) {
     if (board[corner.row][corner.col] === player) {
@@ -234,7 +231,7 @@ const analyzeNextMoveStrength = (board: Board, player: Player): NextMoveStrength
   // 相手の手を大きく制限できるかチェック
   let canSeverelyLimitOpponent = false;
   for (const move of validMoves) {
-    const testBoard = JSON.parse(JSON.stringify(board)) as Board;
+    const testBoard = copyBoard(board);
     // 仮に打ってみる
     testBoard[move.row][move.col] = player;
     const opponentMovesAfter = getAllValidMoves(testBoard, getOpponent(player));

--- a/src/ai/evaluationReasons.ts
+++ b/src/ai/evaluationReasons.ts
@@ -1,6 +1,9 @@
-import { BOARD_SIZE } from '../game/constants';
+import { getAdjacentCorner, isCorner, isCSquare, isEdge, isXSquare } from '../game/boardUtils';
 import { getAllValidMoves, getOpponent } from '../game/rules';
 import type { Board, Player, Position } from '../game/types';
+
+// Re-export for backward compatibility
+export { isCorner, isEdge, isXSquare, isCSquare, getAdjacentCorner };
 
 export interface EvaluationReason {
   type: string;
@@ -8,37 +11,6 @@ export interface EvaluationReason {
   impact: 'positive' | 'negative';
   value: number;
 }
-
-export const isCorner = (pos: Position): boolean => {
-  return (
-    (pos.row === 0 || pos.row === BOARD_SIZE - 1) && (pos.col === 0 || pos.col === BOARD_SIZE - 1)
-  );
-};
-
-export const isEdge = (pos: Position): boolean => {
-  return pos.row === 0 || pos.row === BOARD_SIZE - 1 || pos.col === 0 || pos.col === BOARD_SIZE - 1;
-};
-
-export const isXSquare = (pos: Position): boolean => {
-  return (
-    (pos.row === 1 || pos.row === BOARD_SIZE - 2) && (pos.col === 1 || pos.col === BOARD_SIZE - 2)
-  );
-};
-
-export const isCSquare = (pos: Position): boolean => {
-  const corners = [
-    { row: 0, col: 0 },
-    { row: 0, col: BOARD_SIZE - 1 },
-    { row: BOARD_SIZE - 1, col: 0 },
-    { row: BOARD_SIZE - 1, col: BOARD_SIZE - 1 },
-  ];
-
-  return corners.some((corner) => {
-    const diffRow = Math.abs(pos.row - corner.row);
-    const diffCol = Math.abs(pos.col - corner.col);
-    return (diffRow === 0 && diffCol === 1) || (diffRow === 1 && diffCol === 0);
-  });
-};
 
 export const analyzeMove = (
   board: Board,
@@ -111,12 +83,6 @@ export const analyzeMove = (
   }
 
   return reasons;
-};
-
-export const getAdjacentCorner = (pos: Position): Position => {
-  const row = pos.row <= 1 ? 0 : BOARD_SIZE - 1;
-  const col = pos.col <= 1 ? 0 : BOARD_SIZE - 1;
-  return { row, col };
 };
 
 export const explainEvaluation = (board: Board, position: Position, player: Player): string => {

--- a/src/components/game/BadMoveDialog.debug.test.tsx
+++ b/src/components/game/BadMoveDialog.debug.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createInitialBoard } from '../../game/board';
+import { copyBoard } from '../../game/boardUtils';
 import { getAllValidMoves, getValidMove, makeMove } from '../../game/rules';
 import type { Board } from '../../game/types';
 
@@ -58,7 +59,7 @@ describe('BadMoveDialog - デバッグテスト', () => {
     printBoard(board);
 
     // e6を打つ
-    const e6Board = JSON.parse(JSON.stringify(board)) as Board;
+    const e6Board = copyBoard(board);
     const e6Move = getValidMove(e6Board, { row: 4, col: 5 }, 'black');
     if (e6Move) {
       const afterE6 = makeMove(e6Board, e6Move, 'black');
@@ -76,7 +77,7 @@ describe('BadMoveDialog - デバッグテスト', () => {
     }
 
     // c2を打つ
-    const c2Board = JSON.parse(JSON.stringify(board)) as Board;
+    const c2Board = copyBoard(board);
     const c2Move = getValidMove(c2Board, { row: 1, col: 2 }, 'black');
     if (c2Move) {
       const afterC2 = makeMove(c2Board, c2Move, 'black');

--- a/src/components/game/BadMoveDialog.test.tsx
+++ b/src/components/game/BadMoveDialog.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest';
 import type { DetailedBadMoveAnalysis } from '../../ai/badMoveAnalyzer';
 import type { BadMoveResult } from '../../game/badMoveDetector';
 import { createInitialBoard } from '../../game/board';
+import { copyBoard } from '../../game/boardUtils';
 import { getValidMove, makeMove } from '../../game/rules';
-import type { Board } from '../../game/types';
 import { BadMoveDialog } from './BadMoveDialog';
 
 describe('BadMoveDialog - ストーリーテスト', () => {
@@ -21,7 +21,7 @@ describe('BadMoveDialog - ストーリーテスト', () => {
     if (c3Move) board = makeMove(board, c3Move, 'white');
 
     // この時点が「手を打つ前の盤面」
-    const initialBoard = JSON.parse(JSON.stringify(board)) as Board;
+    const initialBoard = copyBoard(board);
 
     // c2 (1,2) - 黒の手（悪手）(row=2-1=1, col=c-a=2)
     const playerMove = { row: 1, col: 2 };
@@ -112,7 +112,7 @@ describe('BadMoveDialog - ストーリーテスト', () => {
     const c3Move = getValidMove(board, { row: 2, col: 2 }, 'white');
     if (c3Move) board = makeMove(board, c3Move, 'white');
 
-    const initialBoard = JSON.parse(JSON.stringify(board)) as Board;
+    const initialBoard = copyBoard(board);
 
     // c2 (1,2) - 黒の手（悪手）(row=2-1=1, col=c-a=2)
     const playerMove = { row: 1, col: 2 };

--- a/src/game/boardUtils.test.ts
+++ b/src/game/boardUtils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { createInitialBoard } from './board';
+import { copyBoard } from './boardUtils';
+
+describe('boardUtils', () => {
+  describe('copyBoard', () => {
+    it('ボードを正しくコピーする', () => {
+      const original = createInitialBoard();
+      const copy = copyBoard(original);
+
+      // コピーが同じ内容であることを確認
+      expect(copy).toEqual(original);
+
+      // 別のオブジェクトであることを確認
+      expect(copy).not.toBe(original);
+      expect(copy[0]).not.toBe(original[0]);
+    });
+
+    it('コピー後の変更が元のボードに影響しない', () => {
+      const original = createInitialBoard();
+      const copy = copyBoard(original);
+
+      // コピーを変更
+      copy[0][0] = 'black';
+
+      // 元のボードが変更されていないことを確認
+      expect(original[0][0]).toBe(null);
+      expect(copy[0][0]).toBe('black');
+    });
+
+    it('JSON.parse/stringifyより高速である', () => {
+      const board = createInitialBoard();
+      const iterations = 10000;
+
+      // copyBoardの実行時間を測定
+      const copyStart = performance.now();
+      for (let i = 0; i < iterations; i++) {
+        copyBoard(board);
+      }
+      const copyTime = performance.now() - copyStart;
+
+      // JSON.parse/stringifyの実行時間を測定
+      const jsonStart = performance.now();
+      for (let i = 0; i < iterations; i++) {
+        JSON.parse(JSON.stringify(board));
+      }
+      const jsonTime = performance.now() - jsonStart;
+
+      console.log(`copyBoard: ${copyTime.toFixed(2)}ms`);
+      console.log(`JSON.parse/stringify: ${jsonTime.toFixed(2)}ms`);
+      console.log(`改善率: ${((jsonTime / copyTime - 1) * 100).toFixed(1)}%`);
+
+      // copyBoardの方が高速であることを確認
+      expect(copyTime).toBeLessThan(jsonTime);
+    });
+  });
+});

--- a/src/game/boardUtils.ts
+++ b/src/game/boardUtils.ts
@@ -1,0 +1,82 @@
+import { BOARD_SIZE } from './constants';
+import type { Board, Position } from './types';
+
+export const isCorner = (pos: Position): boolean => {
+  return (
+    (pos.row === 0 || pos.row === BOARD_SIZE - 1) && (pos.col === 0 || pos.col === BOARD_SIZE - 1)
+  );
+};
+
+export const isEdge = (pos: Position): boolean => {
+  return pos.row === 0 || pos.row === BOARD_SIZE - 1 || pos.col === 0 || pos.col === BOARD_SIZE - 1;
+};
+
+export const isXSquare = (pos: Position): boolean => {
+  return (
+    (pos.row === 1 || pos.row === BOARD_SIZE - 2) && (pos.col === 1 || pos.col === BOARD_SIZE - 2)
+  );
+};
+
+export const isCSquare = (pos: Position): boolean => {
+  const corners = [
+    { row: 0, col: 0 },
+    { row: 0, col: BOARD_SIZE - 1 },
+    { row: BOARD_SIZE - 1, col: 0 },
+    { row: BOARD_SIZE - 1, col: BOARD_SIZE - 1 },
+  ];
+
+  return corners.some((corner) => {
+    const diffRow = Math.abs(pos.row - corner.row);
+    const diffCol = Math.abs(pos.col - corner.col);
+    return (diffRow === 0 && diffCol === 1) || (diffRow === 1 && diffCol === 0);
+  });
+};
+
+export const getAdjacentCorner = (pos: Position): Position => {
+  const row = pos.row <= 1 ? 0 : BOARD_SIZE - 1;
+  const col = pos.col <= 1 ? 0 : BOARD_SIZE - 1;
+  return { row, col };
+};
+
+export const getAdjacentToCorner = (corner: Position): Position[] => {
+  const adjacent: Position[] = [];
+  const { row, col } = corner;
+
+  // 角の隣接マス（X-square と C-square）
+  if (row === 0 && col === 0) {
+    adjacent.push({ row: 0, col: 1 }, { row: 1, col: 0 }, { row: 1, col: 1 });
+  } else if (row === 0 && col === BOARD_SIZE - 1) {
+    adjacent.push(
+      { row: 0, col: BOARD_SIZE - 2 },
+      { row: 1, col: BOARD_SIZE - 1 },
+      { row: 1, col: BOARD_SIZE - 2 }
+    );
+  } else if (row === BOARD_SIZE - 1 && col === 0) {
+    adjacent.push(
+      { row: BOARD_SIZE - 1, col: 1 },
+      { row: BOARD_SIZE - 2, col: 0 },
+      { row: BOARD_SIZE - 2, col: 1 }
+    );
+  } else if (row === BOARD_SIZE - 1 && col === BOARD_SIZE - 1) {
+    adjacent.push(
+      { row: BOARD_SIZE - 1, col: BOARD_SIZE - 2 },
+      { row: BOARD_SIZE - 2, col: BOARD_SIZE - 1 },
+      { row: BOARD_SIZE - 2, col: BOARD_SIZE - 2 }
+    );
+  }
+
+  return adjacent;
+};
+
+export const getAllCorners = (): Position[] => {
+  return [
+    { row: 0, col: 0 },
+    { row: 0, col: BOARD_SIZE - 1 },
+    { row: BOARD_SIZE - 1, col: 0 },
+    { row: BOARD_SIZE - 1, col: BOARD_SIZE - 1 },
+  ];
+};
+
+export const copyBoard = (board: Board): Board => {
+  return board.map((row) => [...row]);
+};


### PR DESCRIPTION
## 概要
Issue #23 の対応です。

## 変更内容
- `boardEvaluationExplainer.ts`の`JSON.parse(JSON.stringify(board))`を効率的な`copyBoard`関数に置き換え
- テストファイルのディープコピーも同様に置き換え

## パフォーマンス改善
- 約334%の高速化を確認（パフォーマンステストによる）
- `copyBoard`: 6.28ms
- `JSON.parse/stringify`: 27.27ms

## 依存関係
- PR #28 (Issue #14) がマージされることが前提
  - `copyBoard`関数は#14で追加されています

## テスト
- 全てのテストが通過することを確認済み

Closes #23