### PR TITLE
Fix: #31 - 評価値が50で固定される問題

### DIFF
--- a/src/components/game/BadMoveDialog.tsx
+++ b/src/components/game/BadMoveDialog.tsx
@@ -361,7 +361,7 @@ export const BadMoveDialog: FC<BadMoveDialogProps> = ({
                     const isPlayerMove =
                       move.position.row === playerMove.row && move.position.col === playerMove.col;
                     const isBestMove = index === 0;
-                    const isBadMove = index >= analysis.allMoves.length * 0.8;
+                    const isBadMove = index >= (analysis.allMoves?.length || 0) * 0.8;
 
                     // 正規化されたスコアを取得
                     const normalizedScores = getNormalizedScores(move.score);

--- a/src/hooks/useGameWithAI.ts
+++ b/src/hooks/useGameWithAI.ts
@@ -276,17 +276,20 @@ export const useGameWithAI = (playAgainstAI: boolean = true): GameWithAIState =>
   // 深さ4の評価値を計算（メモ化）
   const deepEvaluation = useMemo(() => {
     // ゲーム終了時は計算しない
-    if (gameState.gameStatus !== 'playing') {
+    if (gameState.gameOver) {
       return 0;
     }
     // 絶対的な評価値を計算（マイナス=黒有利、プラス=白有利）
     return minimax(gameState.board, gameState.currentPlayer, 4, -1000000, 1000000);
-  }, [gameState.board, gameState.currentPlayer, gameState.gameStatus]);
+  }, [gameState.board, gameState.currentPlayer, gameState.gameOver]);
 
   // 評価値の更新
   useEffect(() => {
-    setDeepBlackScore(deepEvaluation);
-    setDeepWhiteScore(deepEvaluation);
+    // minimax関数は絶対的な評価値を返す（マイナス=黒有利、プラス=白有利）
+    // UI表示用には、各プレイヤーの視点から見た評価値（0-100の範囲）を計算
+    const normalizedScore = Math.max(0, Math.min(100, 50 + deepEvaluation / 10));
+    setDeepBlackScore(100 - normalizedScore); // 黒の視点：評価値が低いほど有利
+    setDeepWhiteScore(normalizedScore); // 白の視点：評価値が高いほど有利
   }, [deepEvaluation]);
 
   useEffect(() => {


### PR DESCRIPTION
## 問題の概要
メインゲーム画面で評価値が常に50のまま変わらない問題を修正

## 修正内容
- minimax関数の絶対的評価値（マイナス=黒有利、プラス=白有利）を、黒・白それぞれの視点から見た評価値に分けて表示
- 評価値の正規化処理を追加し、0-100の範囲で表示
- TypeScriptエラーの修正（gameStatus → gameOver）
- BadMoveDialog.tsxでのundefinedチェック追加

## テスト結果
- 全テスト通過 (116/116)
- ビルド成功
- リント・フォーマット適用済み

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)