### PR TITLE
Fix: #37 - 画面表示と詳細分析の評価値不一致を修正

### DIFF
--- a/src/hooks/useEvaluation.test.ts
+++ b/src/hooks/useEvaluation.test.ts
@@ -53,8 +53,11 @@ describe('useEvaluation', () => {
       result.current.updateEvaluation(mockGameState);
     });
 
-    expect(result.current.blackScore).toBe(45); // 100 - 55 (50 + 50/10)
-    expect(result.current.whiteScore).toBe(55); // 50 + 50/10
+    // getNormalizedScores(50)の期待値を確認
+    // 50 -> normalizeEvaluation: ((50 + 200) / 400) * 100 = 62.5
+    // blackScore: 100 - 62.5 = 37.5, whiteScore: 62.5
+    expect(result.current.blackScore).toBe(37.5);
+    expect(result.current.whiteScore).toBe(62.5);
   });
 
   it('should detect bad moves correctly', () => {

--- a/src/hooks/useEvaluation.ts
+++ b/src/hooks/useEvaluation.ts
@@ -3,6 +3,7 @@ import { minimax } from '../ai/minimax';
 import type { BadMoveResult } from '../game/badMoveDetector';
 import { BadMoveDetector } from '../game/badMoveDetector';
 import type { Board, GameState, Player, Position } from '../game/types';
+import { getNormalizedScores } from '../utils/evaluationNormalizer';
 
 export interface EvaluationHook {
   blackScore: number;
@@ -43,10 +44,10 @@ export const useEvaluation = (initialAIDepth: number = 4): EvaluationHook => {
     // 絶対的な評価値を計算（マイナス=黒有利、プラス=白有利）
     const evaluation = minimax(gameState.board, gameState.currentPlayer, 4, -1000000, 1000000);
 
-    // UI表示用には、各プレイヤーの視点から見た評価値（0-100の範囲）を計算
-    const normalizedScore = Math.max(0, Math.min(100, 50 + evaluation / 10));
-    setDeepBlackScore(100 - normalizedScore); // 黒の視点：評価値が低いほど有利
-    setDeepWhiteScore(normalizedScore); // 白の視点：評価値が高いほど有利
+    // 統一された正規化関数を使用
+    const { blackScore, whiteScore } = getNormalizedScores(evaluation);
+    setDeepBlackScore(blackScore);
+    setDeepWhiteScore(whiteScore);
   }, []);
 
   const setBeforeMoveScores = useCallback((blackScore: number, whiteScore: number) => {


### PR DESCRIPTION
## Summary
- 画面表示と詳細分析で評価値の正規化方式が異なっていた問題を修正
- useEvaluation.tsで統一されたgetNormalizedScores関数を使用
- テストも更新し品質チェック完了

## Changes
- src/hooks/useEvaluation.ts: 統一された正規化関数を使用
- src/hooks/useEvaluation.test.ts: テスト期待値を新しい正規化に合わせて更新

## Test plan
- [x] 既存テストがすべて通過
- [x] lintエラーなし
- [x] ビルド成功

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)