### PR TITLE
Fix: #39 - 盤面評価値の探索深度を統一

### DIFF
--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -1,4 +1,5 @@
 import { type FC, useState } from 'react';
+import { EVALUATION_CONSTANTS } from '../../constants/ai';
 import type { Player } from '../../game/types';
 import { useGameWithAI } from '../../hooks/useGameWithAI';
 import { AILevelNotification } from './AILevelNotification';
@@ -137,7 +138,7 @@ export const Game: FC = () => {
           initialBoard={boardBeforeLastMove}
           playerMove={lastMoveAnalysis.playerMove}
           playerColor={playerColor}
-          depth={4}
+          depth={EVALUATION_CONSTANTS.EVALUATION_DEPTH}
           onClose={() => {
             setShowAnalysis(false);
           }}

--- a/src/constants/ai.ts
+++ b/src/constants/ai.ts
@@ -20,6 +20,9 @@ export const EVALUATION_CONSTANTS = {
 
   /** 正規化時の最大生スコア */
   MAX_NORMALIZED_SCORE: 200,
+
+  /** 盤面評価の探索深度（AIレベルとは独立） */
+  EVALUATION_DEPTH: 4,
 };
 
 export const GAME_PHASE_CONSTANTS = {

--- a/src/hooks/useEvaluation.ts
+++ b/src/hooks/useEvaluation.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { minimax } from '../ai/minimax';
+import { EVALUATION_CONSTANTS } from '../constants/ai';
 import type { BadMoveResult } from '../game/badMoveDetector';
 import { BadMoveDetector } from '../game/badMoveDetector';
 import type { Board, GameState, Player, Position } from '../game/types';
@@ -33,7 +34,7 @@ export const useEvaluation = (initialAIDepth: number = 4): EvaluationHook => {
   const [deepWhiteScore, setDeepWhiteScore] = useState(50);
   const [badMoveDetector] = useState(() => new BadMoveDetector(initialAIDepth));
 
-  // 深さ4の評価値を計算（メモ化）
+  // 固定深度での盤面評価値を計算
 
   const updateEvaluation = useCallback((gameState: GameState) => {
     // ゲーム終了時は計算しない
@@ -42,7 +43,13 @@ export const useEvaluation = (initialAIDepth: number = 4): EvaluationHook => {
     }
 
     // 絶対的な評価値を計算（マイナス=黒有利、プラス=白有利）
-    const evaluation = minimax(gameState.board, gameState.currentPlayer, 4, -1000000, 1000000);
+    const evaluation = minimax(
+      gameState.board,
+      gameState.currentPlayer,
+      EVALUATION_CONSTANTS.EVALUATION_DEPTH,
+      EVALUATION_CONSTANTS.MIN_SCORE,
+      EVALUATION_CONSTANTS.MAX_SCORE
+    );
 
     // 統一された正規化関数を使用
     const { blackScore, whiteScore } = getNormalizedScores(evaluation);


### PR DESCRIPTION
## Summary
- 盤面評価とAIレベルを分離し、評価値表示の一貫性を確保
- EVALUATION_CONSTANTS.EVALUATION_DEPTH定数を追加してマジックナンバーを削除
- useEvaluationとBadMoveDialogで同じ探索深度4を使用

## Changes
- src/constants/ai.ts: EVALUATION_DEPTH定数を追加
- src/hooks/useEvaluation.ts: 固定深度での評価値計算に変更
- src/components/game/Game.tsx: BadMoveDialogで統一された深度を使用

## Test plan
- [x] 全テスト通過 (181テスト)
- [x] lint/formatエラーなし
- [x] ビルド成功

Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)