### PR TITLE
Fix: #27 - キャッシュクリアのタイミング管理

### DIFF
--- a/src/ai/cache/cacheManager.test.ts
+++ b/src/ai/cache/cacheManager.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { globalBoardCache } from './boardCache';
+import {
+  clearAllCaches,
+  clearCachesOnGameEnd,
+  clearCachesOnGameStart,
+  getCacheStats,
+} from './cacheManager';
+import { globalValidMovesCache } from './validMovesCache';
+
+vi.mock('./boardCache', () => ({
+  globalBoardCache: {
+    clear: vi.fn(),
+    getStats: vi.fn(() => ({ hits: 10, misses: 5, hitRate: '67.00%', size: 50, maxSize: 100000 })),
+  },
+}));
+
+vi.mock('./validMovesCache', () => ({
+  globalValidMovesCache: {
+    clear: vi.fn(),
+    getStats: vi.fn(() => ({ hits: 20, misses: 10, hitRate: '67.00%', size: 30, maxSize: 50000 })),
+  },
+}));
+
+describe('Cache Manager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('clearAllCaches', () => {
+    it('should clear both board cache and valid moves cache', () => {
+      clearAllCaches();
+
+      expect(globalBoardCache.clear).toHaveBeenCalledTimes(1);
+      expect(globalValidMovesCache.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle errors gracefully', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(globalBoardCache.clear).mockImplementationOnce(() => {
+        throw new Error('Board cache clear failed');
+      });
+
+      expect(() => clearAllCaches()).not.toThrow();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to clear caches:', expect.any(Error));
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('getCacheStats', () => {
+    it('should return combined statistics from both caches', () => {
+      const stats = getCacheStats();
+
+      expect(stats).toEqual({
+        boardCache: {
+          hits: 10,
+          misses: 5,
+          hitRate: 0.67,
+        },
+        validMovesCache: {
+          hits: 20,
+          misses: 10,
+          hitRate: 0.67,
+        },
+        combined: {
+          totalHits: 30,
+          totalMisses: 15,
+          totalHitRate: 0.6666666666666666,
+        },
+      });
+    });
+
+    it('should handle missing statistics gracefully', () => {
+      vi.mocked(globalBoardCache.getStats).mockReturnValueOnce({
+        hits: 0,
+        misses: 0,
+        hitRate: '0.00%',
+        size: 0,
+        maxSize: 100000,
+      });
+      vi.mocked(globalValidMovesCache.getStats).mockReturnValueOnce({
+        hits: 0,
+        misses: 0,
+        hitRate: '0.00%',
+        size: 0,
+        maxSize: 50000,
+      });
+
+      const stats = getCacheStats();
+
+      expect(stats.combined).toEqual({
+        totalHits: 0,
+        totalMisses: 0,
+        totalHitRate: 0,
+      });
+    });
+  });
+
+  describe('clearCachesOnGameStart', () => {
+    it('should clear all caches when called', () => {
+      clearCachesOnGameStart();
+
+      expect(globalBoardCache.clear).toHaveBeenCalledTimes(1);
+      expect(globalValidMovesCache.clear).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clearCachesOnGameEnd', () => {
+    it('should clear all caches when called', () => {
+      clearCachesOnGameEnd();
+
+      expect(globalBoardCache.clear).toHaveBeenCalledTimes(1);
+      expect(globalValidMovesCache.clear).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/ai/cache/cacheManager.ts
+++ b/src/ai/cache/cacheManager.ts
@@ -1,0 +1,69 @@
+import { globalBoardCache } from './boardCache';
+import { globalValidMovesCache } from './validMovesCache';
+
+export interface CacheStatistics {
+  boardCache: {
+    hits: number;
+    misses: number;
+    hitRate: number;
+  };
+  validMovesCache: {
+    hits: number;
+    misses: number;
+    hitRate: number;
+  };
+  combined: {
+    totalHits: number;
+    totalMisses: number;
+    totalHitRate: number;
+  };
+}
+
+export function clearAllCaches(): void {
+  try {
+    globalBoardCache.clear();
+    globalValidMovesCache.clear();
+  } catch (error) {
+    console.error('Failed to clear caches:', error);
+  }
+}
+
+export function getCacheStats(): CacheStatistics {
+  const boardStats = globalBoardCache.getStats();
+  const validMovesStats = globalValidMovesCache.getStats();
+
+  // hitRateを文字列から数値に変換
+  const boardHitRate = Number.parseFloat(boardStats.hitRate.replace('%', '')) / 100;
+  const validMovesHitRate = Number.parseFloat(validMovesStats.hitRate.replace('%', '')) / 100;
+
+  const totalHits = boardStats.hits + validMovesStats.hits;
+  const totalMisses = boardStats.misses + validMovesStats.misses;
+  const totalAttempts = totalHits + totalMisses;
+  const totalHitRate = totalAttempts > 0 ? totalHits / totalAttempts : 0;
+
+  return {
+    boardCache: {
+      hits: boardStats.hits,
+      misses: boardStats.misses,
+      hitRate: boardHitRate,
+    },
+    validMovesCache: {
+      hits: validMovesStats.hits,
+      misses: validMovesStats.misses,
+      hitRate: validMovesHitRate,
+    },
+    combined: {
+      totalHits,
+      totalMisses,
+      totalHitRate,
+    },
+  };
+}
+
+export function clearCachesOnGameStart(): void {
+  clearAllCaches();
+}
+
+export function clearCachesOnGameEnd(): void {
+  clearAllCaches();
+}

--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -2,15 +2,12 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useGameState } from './useGameState';
 
-vi.mock('../ai/cache/boardCache', () => ({
-  globalBoardCache: {
-    clear: vi.fn(),
-  },
+vi.mock('../ai/cache/cacheManager', () => ({
+  clearCachesOnGameStart: vi.fn(),
 }));
 
 vi.mock('../ai/cache/validMovesCache', () => ({
   globalValidMovesCache: {
-    clear: vi.fn(),
     get: vi.fn(() => null),
     set: vi.fn(),
   },

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from 'react';
-import { globalBoardCache } from '../ai/cache/boardCache';
-import { globalValidMovesCache } from '../ai/cache/validMovesCache';
+import { clearCachesOnGameStart } from '../ai/cache/cacheManager';
 import { countPieces } from '../game/board';
 import { createInitialGameState, playMove, playPass } from '../game/gameState';
 import { getAllValidMoves } from '../game/rules';
@@ -44,16 +43,14 @@ export const useGameState = (): GameStateHook => {
   const resetGame = useCallback(() => {
     setGameState(createInitialGameState());
     setIsPassTurn(false);
-    globalBoardCache.clear();
-    globalValidMovesCache.clear();
+    clearCachesOnGameStart();
   }, []);
 
   const resetGameWithColor = useCallback((newPlayerColor: Player) => {
     setPlayerColor(newPlayerColor);
     setGameState(createInitialGameState());
     setIsPassTurn(false);
-    globalBoardCache.clear();
-    globalValidMovesCache.clear();
+    clearCachesOnGameStart();
   }, []);
 
   const undoLastMove = useCallback(() => {


### PR DESCRIPTION
## Summary
- キャッシュ管理を一元化するためのCacheManagerモジュールを実装
- globalBoardCacheとglobalValidMovesCacheの個別清理を統合  
- 関数ベースのAPIで静的クラスの代替
- ゲーム開始時の統一されたキャッシュクリア機能

## Test plan
- [x] 全テストが通過
- [x] Lintエラーなし
- [x] ビルド成功
- [x] キャッシュクリア機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)