### PR TITLE
Fix: #15 - ムーブオーダリング関数の重複

### DIFF
--- a/src/ai/moveOrdering.test.ts
+++ b/src/ai/moveOrdering.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { Position } from '../game/types';
+
+// テスト用の関数をインポート（実装後に利用）
+import { compareMovesByPriority, getMovePositionPriority, isCorner, isEdge } from './moveOrdering';
+
+describe('Move Ordering Utility Functions', () => {
+  describe('isCorner', () => {
+    it('should identify corner positions correctly', () => {
+      expect(isCorner({ row: 0, col: 0 })).toBe(true);
+      expect(isCorner({ row: 0, col: 7 })).toBe(true);
+      expect(isCorner({ row: 7, col: 0 })).toBe(true);
+      expect(isCorner({ row: 7, col: 7 })).toBe(true);
+    });
+
+    it('should return false for non-corner positions', () => {
+      expect(isCorner({ row: 0, col: 1 })).toBe(false);
+      expect(isCorner({ row: 1, col: 0 })).toBe(false);
+      expect(isCorner({ row: 3, col: 3 })).toBe(false);
+      expect(isCorner({ row: 7, col: 6 })).toBe(false);
+    });
+  });
+
+  describe('isEdge', () => {
+    it('should identify edge positions correctly', () => {
+      expect(isEdge({ row: 0, col: 3 })).toBe(true);
+      expect(isEdge({ row: 7, col: 4 })).toBe(true);
+      expect(isEdge({ row: 3, col: 0 })).toBe(true);
+      expect(isEdge({ row: 4, col: 7 })).toBe(true);
+    });
+
+    it('should return true for corners (corners are also edges)', () => {
+      expect(isEdge({ row: 0, col: 0 })).toBe(true);
+      expect(isEdge({ row: 7, col: 7 })).toBe(true);
+    });
+
+    it('should return false for center positions', () => {
+      expect(isEdge({ row: 3, col: 3 })).toBe(false);
+      expect(isEdge({ row: 4, col: 4 })).toBe(false);
+      expect(isEdge({ row: 2, col: 5 })).toBe(false);
+    });
+  });
+
+  describe('getMovePositionPriority', () => {
+    it('should return highest priority for corners', () => {
+      expect(getMovePositionPriority({ row: 0, col: 0 })).toBe(2);
+      expect(getMovePositionPriority({ row: 7, col: 7 })).toBe(2);
+    });
+
+    it('should return medium priority for edges', () => {
+      expect(getMovePositionPriority({ row: 0, col: 3 })).toBe(1);
+      expect(getMovePositionPriority({ row: 3, col: 7 })).toBe(1);
+    });
+
+    it('should return lowest priority for center positions', () => {
+      expect(getMovePositionPriority({ row: 3, col: 3 })).toBe(0);
+      expect(getMovePositionPriority({ row: 4, col: 4 })).toBe(0);
+    });
+  });
+
+  describe('compareMovesByPriority', () => {
+    it('should prioritize corners over edges', () => {
+      const corner: Position = { row: 0, col: 0 };
+      const edge: Position = { row: 0, col: 3 };
+      expect(compareMovesByPriority(corner, edge)).toBe(-1);
+      expect(compareMovesByPriority(edge, corner)).toBe(1);
+    });
+
+    it('should prioritize edges over center', () => {
+      const edge: Position = { row: 0, col: 3 };
+      const center: Position = { row: 3, col: 3 };
+      expect(compareMovesByPriority(edge, center)).toBe(-1);
+      expect(compareMovesByPriority(center, edge)).toBe(1);
+    });
+
+    it('should return 0 for positions with same priority', () => {
+      const corner1: Position = { row: 0, col: 0 };
+      const corner2: Position = { row: 7, col: 7 };
+      const edge1: Position = { row: 0, col: 3 };
+      const edge2: Position = { row: 3, col: 7 };
+      const center1: Position = { row: 3, col: 3 };
+      const center2: Position = { row: 4, col: 4 };
+
+      expect(compareMovesByPriority(corner1, corner2)).toBe(0);
+      expect(compareMovesByPriority(edge1, edge2)).toBe(0);
+      expect(compareMovesByPriority(center1, center2)).toBe(0);
+    });
+
+    it('should handle previous best move priority correctly', () => {
+      const previousBest: Position = { row: 3, col: 3 };
+      const corner: Position = { row: 0, col: 0 };
+
+      // Previous best should have highest priority
+      expect(compareMovesByPriority(previousBest, corner, previousBest)).toBe(-1);
+      expect(compareMovesByPriority(corner, previousBest, previousBest)).toBe(1);
+    });
+
+    it('should fall back to position priority when no previous best', () => {
+      const corner: Position = { row: 0, col: 0 };
+      const edge: Position = { row: 0, col: 3 };
+
+      expect(compareMovesByPriority(corner, edge)).toBe(-1);
+      expect(compareMovesByPriority(edge, corner)).toBe(1);
+    });
+  });
+
+  describe('Integration with arrays', () => {
+    it('should sort moves correctly by priority', () => {
+      const moves: Position[] = [
+        { row: 3, col: 3 }, // center
+        { row: 0, col: 0 }, // corner
+        { row: 0, col: 3 }, // edge
+        { row: 7, col: 7 }, // corner
+        { row: 4, col: 4 }, // center
+        { row: 3, col: 7 }, // edge
+      ];
+
+      const sorted = moves.sort(compareMovesByPriority);
+
+      // Should be: corners first, then edges, then centers
+      expect(getMovePositionPriority(sorted[0])).toBe(2); // corner
+      expect(getMovePositionPriority(sorted[1])).toBe(2); // corner
+      expect(getMovePositionPriority(sorted[2])).toBe(1); // edge
+      expect(getMovePositionPriority(sorted[3])).toBe(1); // edge
+      expect(getMovePositionPriority(sorted[4])).toBe(0); // center
+      expect(getMovePositionPriority(sorted[5])).toBe(0); // center
+    });
+
+    it('should prioritize previous best move', () => {
+      const moves: Position[] = [
+        { row: 0, col: 0 }, // corner
+        { row: 3, col: 3 }, // center (previous best)
+        { row: 0, col: 3 }, // edge
+      ];
+      const previousBest: Position = { row: 3, col: 3 };
+
+      const sorted = moves.sort((a, b) => compareMovesByPriority(a, b, previousBest));
+
+      // Previous best should be first
+      expect(sorted[0]).toEqual(previousBest);
+    });
+  });
+});

--- a/src/ai/moveOrdering.ts
+++ b/src/ai/moveOrdering.ts
@@ -1,0 +1,61 @@
+import type { Position } from '../game/types';
+
+/**
+ * 指定された位置が角（コーナー）かどうかを判定する
+ */
+export const isCorner = (position: Position): boolean => {
+  return (position.row === 0 || position.row === 7) && (position.col === 0 || position.col === 7);
+};
+
+/**
+ * 指定された位置が辺（エッジ）かどうかを判定する
+ * 注：角も辺に含まれる
+ */
+export const isEdge = (position: Position): boolean => {
+  return position.row === 0 || position.row === 7 || position.col === 0 || position.col === 7;
+};
+
+/**
+ * 手の位置に基づく優先度を取得する
+ * @param position 手の位置
+ * @returns 優先度（2: 角, 1: 辺, 0: 中央）
+ */
+export const getMovePositionPriority = (position: Position): number => {
+  if (isCorner(position)) {
+    return 2; // 角は最高優先度
+  }
+  if (isEdge(position)) {
+    return 1; // 辺は中程度の優先度
+  }
+  return 0; // 中央は最低優先度
+};
+
+/**
+ * 手の優先順位を比較する関数
+ * @param a 比較する手A
+ * @param b 比較する手B
+ * @param previousBest 前回の最善手（オプション）
+ * @returns -1 if a > b, 1 if b > a, 0 if equal priority
+ */
+export const compareMovesByPriority = (
+  a: Position,
+  b: Position,
+  previousBest?: Position
+): number => {
+  // 前回の最善手がある場合は最優先
+  if (previousBest) {
+    const isAPreviousBest = a.row === previousBest.row && a.col === previousBest.col;
+    const isBPreviousBest = b.row === previousBest.row && b.col === previousBest.col;
+
+    if (isAPreviousBest && !isBPreviousBest) return -1;
+    if (!isAPreviousBest && isBPreviousBest) return 1;
+  }
+
+  // 位置の優先度で比較
+  const priorityA = getMovePositionPriority(a);
+  const priorityB = getMovePositionPriority(b);
+
+  if (priorityA > priorityB) return -1;
+  if (priorityA < priorityB) return 1;
+  return 0;
+};


### PR DESCRIPTION
## Summary
- ムーブオーダリング関数の重複ロジックを共通化
- 保守性向上（変更時は1箇所のみ修正）
- AI性能は維持したまま、コードの重複を削除

## Changes
- `src/ai/moveOrdering.ts`: 新規ファイル作成
  - `isCorner`: 角の判定関数
  - `isEdge`: 辺の判定関数  
  - `getMovePositionPriority`: 位置優先度取得関数
  - `compareMovesByPriority`: 優先順位比較関数
- `src/ai/minimax.ts`: 重複ロジックを共通関数に置き換え
  - `orderMoves`関数内の2箇所の重複削除
  - `findBestMove`関数内の1箇所の重複削除
- `src/ai/moveOrdering.test.ts`: 包括的なテスト追加（15テスト）

## Test plan
- [x] 既存のテストがすべて通過することを確認
- [x] 新しいテストで共通関数の動作を検証
- [x] AI性能への影響がないことを確認
- [x] リント、テスト、ビルドがすべて成功することを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)