### PR TITLE
Fix: #22 - スコア関連の命名不統一を解決

### DIFF
--- a/src/components/game/BadMoveDialog.tsx
+++ b/src/components/game/BadMoveDialog.tsx
@@ -161,15 +161,13 @@ export const BadMoveDialog: FC<BadMoveDialogProps> = ({
                         highlightType="player-move"
                       />
                       <EvaluationSummary
-                        playerScore={(() => {
-                          const { blackScore, whiteScore } =
-                            getNormalizedScores(playerMoveEvaluation);
-                          return playerColor === 'black' ? blackScore : whiteScore;
+                        blackScore={(() => {
+                          const { blackScore } = getNormalizedScores(playerMoveEvaluation);
+                          return blackScore;
                         })()}
-                        aiScore={(() => {
-                          const { blackScore, whiteScore } =
-                            getNormalizedScores(playerMoveEvaluation);
-                          return playerColor === 'black' ? whiteScore : blackScore;
+                        whiteScore={(() => {
+                          const { whiteScore } = getNormalizedScores(playerMoveEvaluation);
+                          return whiteScore;
                         })()}
                         explanation={playerMoveExplanation}
                       />
@@ -186,17 +184,13 @@ export const BadMoveDialog: FC<BadMoveDialogProps> = ({
                           highlightType="ai-recommendation"
                         />
                         <EvaluationSummary
-                          playerScore={(() => {
-                            const { blackScore, whiteScore } = getNormalizedScores(
-                              aiRecommendationEvaluation
-                            );
-                            return playerColor === 'black' ? blackScore : whiteScore;
+                          blackScore={(() => {
+                            const { blackScore } = getNormalizedScores(aiRecommendationEvaluation);
+                            return blackScore;
                           })()}
-                          aiScore={(() => {
-                            const { blackScore, whiteScore } = getNormalizedScores(
-                              aiRecommendationEvaluation
-                            );
-                            return playerColor === 'black' ? whiteScore : blackScore;
+                          whiteScore={(() => {
+                            const { whiteScore } = getNormalizedScores(aiRecommendationEvaluation);
+                            return whiteScore;
                           })()}
                           explanation={aiMoveExplanation}
                         />

--- a/src/components/game/EvaluationSummary.test.tsx
+++ b/src/components/game/EvaluationSummary.test.tsx
@@ -40,20 +40,20 @@ describe('EvaluationSummary', () => {
   };
 
   it('renders evaluation scores', () => {
-    render(<EvaluationSummary playerScore={65.5} aiScore={34.5} explanation={mockExplanation} />);
+    render(<EvaluationSummary blackScore={65.5} whiteScore={34.5} explanation={mockExplanation} />);
 
-    expect(screen.getByText(/あなた: 65.5/)).toBeInTheDocument();
-    expect(screen.getByText(/AI: 34.5/)).toBeInTheDocument();
+    expect(screen.getByText(/黒: 65.5/)).toBeInTheDocument();
+    expect(screen.getByText(/白: 34.5/)).toBeInTheDocument();
   });
 
   it('shows overall assessment', () => {
-    render(<EvaluationSummary playerScore={65.5} aiScore={34.5} explanation={mockExplanation} />);
+    render(<EvaluationSummary blackScore={65.5} whiteScore={34.5} explanation={mockExplanation} />);
 
     expect(screen.getByText('テスト評価')).toBeInTheDocument();
   });
 
   it('displays board analysis section', () => {
-    render(<EvaluationSummary playerScore={65.5} aiScore={34.5} explanation={mockExplanation} />);
+    render(<EvaluationSummary blackScore={65.5} whiteScore={34.5} explanation={mockExplanation} />);
 
     expect(screen.getByText('盤面分析')).toBeInTheDocument();
   });

--- a/src/components/game/EvaluationSummary.tsx
+++ b/src/components/game/EvaluationSummary.tsx
@@ -5,20 +5,20 @@ import {
 } from '../../ai/boardEvaluationExplainer';
 
 interface EvaluationSummaryProps {
-  playerScore: number;
-  aiScore: number;
+  blackScore: number;
+  whiteScore: number;
   explanation: BoardEvaluationExplanation;
 }
 
 export const EvaluationSummary: FC<EvaluationSummaryProps> = ({
-  playerScore,
-  aiScore,
+  blackScore,
+  whiteScore,
   explanation,
 }) => {
   return (
     <div className="board-evaluation">
       <div className="eval-score">
-        あなた: {playerScore.toFixed(1)} vs AI: {aiScore.toFixed(1)}
+        黒: {blackScore.toFixed(1)} vs 白: {whiteScore.toFixed(1)}
       </div>
       <div className="board-analysis">
         <h4>盤面分析</h4>


### PR DESCRIPTION
## Summary
- EvaluationSummaryコンポーネントでplayerScore/aiScoreをblackScore/whiteScoreに統一
- BadMoveDialogコンポーネントでの評価表示を統一された命名規則に更新
- 表示コンテキストでの一貫した命名（blackScore/whiteScore）を確立

## 修正内容
1. **EvaluationSummary.tsx**: インターフェースと実装をblackScore/whiteScoreに変更
2. **EvaluationSummary.test.tsx**: テストケースを新しい命名規則に更新  
3. **BadMoveDialog.tsx**: 評価表示部分を統一された命名に変更

## 確認済み事項
- 内部計算コンテキストでの命名（evaluation）はすでに適切に統一されている
- useEvaluationフックは既にblackScore/whiteScoreを使用している
- 型安全性は保持されている（EvaluationScore/NormalizedScore）

## Test Plan
- [x] 全テストが通過することを確認
- [x] リントエラーがないことを確認
- [x] ビルドが成功することを確認

Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)