### PR TITLE
Fix: #60 - 一手戻る機能で過去の手の分析情報が消える問題

### DIFF
--- a/src/hooks/__tests__/useEvaluation.undo-analysis.test.ts
+++ b/src/hooks/__tests__/useEvaluation.undo-analysis.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { createInitialBoard } from '../../game/board';
+import { createInitialGameState } from '../../game/gameState';
+import type { Position } from '../../game/types';
+import { useEvaluation } from '../useEvaluation';
+
+describe('useEvaluation - Move Analysis Persistence', () => {
+  it('should restore analysis for the current game state', () => {
+    const { result } = renderHook(() => useEvaluation(4));
+
+    // Create a mock game state with some moves
+    const initialBoard = createInitialBoard();
+    const gameState = {
+      ...createInitialGameState(),
+      fullMoveHistory: [
+        {
+          type: 'move' as const,
+          position: { row: 2, col: 3 } as Position, // d3
+          player: 'black' as const,
+          boardBefore: initialBoard,
+          boardAfter: initialBoard,
+        },
+        {
+          type: 'move' as const,
+          position: { row: 2, col: 4 } as Position, // e3
+          player: 'white' as const,
+          boardBefore: initialBoard,
+          boardAfter: initialBoard,
+        },
+      ],
+    };
+
+    // Simulate making moves and analyzing them
+    act(() => {
+      const firstAnalysis = result.current.analyzeBadMove(
+        initialBoard,
+        { row: 2, col: 3 },
+        'black',
+        'black'
+      );
+      expect(firstAnalysis).toBeTruthy();
+    });
+
+    // Store first analysis for later verification if needed
+
+    act(() => {
+      const secondAnalysis = result.current.analyzeBadMove(
+        initialBoard,
+        { row: 2, col: 4 },
+        'white',
+        'black' // Player is still black
+      );
+      expect(secondAnalysis).toBeTruthy();
+    });
+
+    // Should now show the latest analysis (which wasn't the player's move, so no history saved)
+    expect(result.current.lastMoveAnalysis).toBeTruthy();
+
+    // Simulate undoing back to first move state
+    const gameStateAfterUndo = {
+      ...gameState,
+      fullMoveHistory: [gameState.fullMoveHistory[0]], // Only first move remains
+    };
+
+    act(() => {
+      result.current.restoreAnalysisForGameState(gameStateAfterUndo, 'black');
+    });
+
+    // Should restore the analysis for the first move
+    expect(result.current.lastMoveAnalysis).toBeTruthy();
+    expect(result.current.lastMoveAnalysis?.playerMove).toEqual({ row: 2, col: 3 });
+  });
+
+  it('should clear analysis when no moves remain', () => {
+    const { result } = renderHook(() => useEvaluation(4));
+
+    // Make a move first
+    act(() => {
+      result.current.analyzeBadMove(createInitialBoard(), { row: 2, col: 3 }, 'black', 'black');
+    });
+
+    expect(result.current.lastMoveAnalysis).toBeTruthy();
+
+    // Simulate empty game state (all moves undone)
+    const emptyGameState = createInitialGameState();
+
+    act(() => {
+      result.current.restoreAnalysisForGameState(emptyGameState, 'black');
+    });
+
+    // Should clear analysis
+    expect(result.current.lastMoveAnalysis).toBeNull();
+  });
+});

--- a/src/hooks/useGameWithAI.ts
+++ b/src/hooks/useGameWithAI.ts
@@ -107,7 +107,9 @@ export const useGameWithAI = (playAgainstAI: boolean = true): GameWithAIState =>
     if (aiPlayer.isAIThinking) return;
 
     gameState.undoLastMove();
-    evaluation.clearLastMoveAnalysis();
+
+    // Restore analysis for the new current game state instead of clearing
+    evaluation.restoreAnalysisForGameState(gameState.gameState, gameState.playerColor);
 
     // プレイヤーが白で、最初の状態に戻った場合、AIに最初の手を打たせる
     if (gameState.playerColor === 'white' && gameState.gameState.moveHistory.length === 0) {


### PR DESCRIPTION
Closes #60

## 変更内容

一手戻る機能で過去の手の分析情報が消える問題を修正しました。

### 主な変更

#### 
- 手の分析履歴を保存する機能を追加（）
- 関数を追加し、ゲーム状態に基づいて適切な分析を復元
- 手を戻した際に、戻った手の分析情報を再表示する機能を実装

####  
- での代わりにを呼び出し
- 一手戻る際に分析情報をクリアするのではなく、適切な分析を復元するように変更

### 動作
- **修正前**: 一手戻ると分析情報（「前回の手」と「詳細分析」ボタン）が消えていた  
- **修正後**: 一手戻ると、その時点で最後に打った手の分析情報が正しく表示される
- **初期状態**: すべての手を戻した場合は分析情報は正しくクリアされる

### テスト
- : コア機能のユニットテストを追加
- 既存テストとの互換性を保持

これにより、ユーザーは過去の手について再分析できるようになり、学習効果が向上します。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>