### PR TITLE
Fix: #63 - 統合評価システムの符号変換修正

### DIFF
--- a/src/ai/__tests__/unifiedEvaluation.sign.test.ts
+++ b/src/ai/__tests__/unifiedEvaluation.sign.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { createInitialBoard } from '../../game/board';
+import type { Board } from '../../game/types';
+import { generateEvaluationExplanation, performUnifiedEvaluation } from '../unifiedEvaluation';
+
+describe('統合評価システム - 符号変換テスト', () => {
+  describe('プレイヤー視点での符号変換', () => {
+    it('黒プレイヤー：負のスコアで有利判定', () => {
+      const board = createInitialBoard();
+      // 負のスコア（黒有利）をシミュレート
+      const evaluation = performUnifiedEvaluation(board, 'black', 3, -20);
+      const explanations = generateEvaluationExplanation(evaluation, 'black');
+
+      // 黒プレイヤーにとって-20は有利なので、有利な説明が含まれるべき
+      const hasAdvantageExplanation = explanations.some(
+        (exp) => exp.includes('✓') && exp.includes('有利')
+      );
+      expect(hasAdvantageExplanation).toBe(true);
+
+      // 「不利」な説明は含まれないべき
+      const hasDisadvantageExplanation = explanations.some(
+        (exp) => exp.includes('×') && exp.includes('不利')
+      );
+      expect(hasDisadvantageExplanation).toBe(false);
+    });
+
+    it('黒プレイヤー：正のスコアで不利判定', () => {
+      const board = createInitialBoard();
+      // 正のスコア（白有利）をシミュレート
+      const evaluation = performUnifiedEvaluation(board, 'black', 3, 20);
+      const explanations = generateEvaluationExplanation(evaluation, 'black');
+
+      // 黒プレイヤーにとって+20は不利なので、不利な説明が含まれるべき
+      const hasDisadvantageExplanation = explanations.some(
+        (exp) => exp.includes('×') && exp.includes('不利')
+      );
+      expect(hasDisadvantageExplanation).toBe(true);
+
+      // 「有利」な説明は含まれないべき
+      const hasAdvantageExplanation = explanations.some(
+        (exp) => exp.includes('✓') && exp.includes('有利')
+      );
+      expect(hasAdvantageExplanation).toBe(false);
+    });
+
+    it('白プレイヤー：正のスコアで有利判定', () => {
+      const board = createInitialBoard();
+      // 正のスコア（白有利）をシミュレート
+      const evaluation = performUnifiedEvaluation(board, 'white', 3, 20);
+      const explanations = generateEvaluationExplanation(evaluation, 'white');
+
+      // 白プレイヤーにとって+20は有利なので、有利な説明が含まれるべき
+      const hasAdvantageExplanation = explanations.some(
+        (exp) => exp.includes('✓') && exp.includes('有利')
+      );
+      expect(hasAdvantageExplanation).toBe(true);
+
+      // 「不利」な説明は含まれないべき
+      const hasDisadvantageExplanation = explanations.some(
+        (exp) => exp.includes('×') && exp.includes('不利')
+      );
+      expect(hasDisadvantageExplanation).toBe(false);
+    });
+
+    it('白プレイヤー：負のスコアで不利判定', () => {
+      const board = createInitialBoard();
+      // 負のスコア（黒有利）をシミュレート
+      const evaluation = performUnifiedEvaluation(board, 'white', 3, -20);
+      const explanations = generateEvaluationExplanation(evaluation, 'white');
+
+      // 白プレイヤーにとって-20は不利なので、不利な説明が含まれるべき
+      const hasDisadvantageExplanation = explanations.some(
+        (exp) => exp.includes('×') && exp.includes('不利')
+      );
+      expect(hasDisadvantageExplanation).toBe(true);
+
+      // 「有利」な説明は含まれないべき
+      const hasAdvantageExplanation = explanations.some(
+        (exp) => exp.includes('✓') && exp.includes('有利')
+      );
+      expect(hasAdvantageExplanation).toBe(false);
+    });
+  });
+
+  describe('スコア絶対値による判定レベル', () => {
+    it('大きなスコア差（50）で「大きく有利/不利」判定', () => {
+      const board = createInitialBoard();
+
+      // 黒プレイヤーで大きく有利
+      const blackAdvantage = performUnifiedEvaluation(board, 'black', 3, -50);
+      const blackExplanations = generateEvaluationExplanation(blackAdvantage, 'black');
+
+      expect(blackExplanations.some((exp) => exp.includes('大きく') && exp.includes('有利'))).toBe(
+        true
+      );
+
+      // 白プレイヤーで大きく不利
+      const whiteDisadvantage = performUnifiedEvaluation(board, 'white', 3, -50);
+      const whiteExplanations = generateEvaluationExplanation(whiteDisadvantage, 'white');
+
+      expect(whiteExplanations.some((exp) => exp.includes('大きく') && exp.includes('不利'))).toBe(
+        true
+      );
+    });
+
+    it('中程度のスコア差（20）で「有利/不利」判定', () => {
+      const board = createInitialBoard();
+
+      const evaluation = performUnifiedEvaluation(board, 'black', 3, -20);
+      const explanations = generateEvaluationExplanation(evaluation, 'black');
+
+      // 「非常に」は含まれず、「有利」が含まれる
+      expect(explanations.some((exp) => exp.includes('非常に'))).toBe(false);
+      expect(explanations.some((exp) => exp.includes('✓') && exp.includes('有利'))).toBe(true);
+    });
+
+    it('小さなスコア差（5）で「互角」判定', () => {
+      const board = createInitialBoard();
+
+      const evaluation = performUnifiedEvaluation(board, 'black', 3, -5);
+      const explanations = generateEvaluationExplanation(evaluation, 'black');
+
+      expect(explanations.some((exp) => exp.includes('互角'))).toBe(true);
+    });
+  });
+
+  describe('評価値の一貫性', () => {
+    it('同じ盤面で黒と白の評価が逆転する', () => {
+      const board: Board = Array(8)
+        .fill(null)
+        .map(() => Array(8).fill(null));
+
+      // 明確に黒有利な状況を作成
+      board[0][0] = 'black'; // 角
+      board[3][3] = 'black';
+      board[3][4] = 'white';
+      board[4][3] = 'white';
+      board[4][4] = 'white';
+
+      const blackEval = performUnifiedEvaluation(board, 'black', 3, -30);
+      const whiteEval = performUnifiedEvaluation(board, 'white', 3, -30); // 同じ負のスコア
+
+      const blackExplanations = generateEvaluationExplanation(blackEval, 'black');
+      const whiteExplanations = generateEvaluationExplanation(whiteEval, 'white');
+
+      // 黒は有利、白は不利と判定されるべき
+      const blackHasAdvantage = blackExplanations.some(
+        (exp) => exp.includes('✓') && exp.includes('有利')
+      );
+      const whiteHasDisadvantage = whiteExplanations.some(
+        (exp) => exp.includes('×') && exp.includes('不利')
+      );
+
+      expect(blackHasAdvantage).toBe(true);
+      expect(whiteHasDisadvantage).toBe(true);
+    });
+  });
+});

--- a/src/ai/__tests__/unifiedEvaluation.test.ts
+++ b/src/ai/__tests__/unifiedEvaluation.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import { createInitialBoard } from '../../game/board';
+import type { Board } from '../../game/types';
+import { generateEvaluationExplanation, performUnifiedEvaluation } from '../unifiedEvaluation';
+
+describe('統合評価システム', () => {
+  describe('performUnifiedEvaluation', () => {
+    it('初期盤面で互角の評価を返す', () => {
+      const board = createInitialBoard();
+      const evaluation = performUnifiedEvaluation(board, 'black');
+
+      expect(evaluation.totalScore).toBeCloseTo(0, 1);
+      expect(evaluation.gamePhase.phase).toBe('early');
+      expect(evaluation.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('黒有利な盤面で黒に有利な評価を返す', () => {
+      const board: Board = Array(8)
+        .fill(null)
+        .map(() => Array(8).fill(null));
+
+      // 黒が角を取った状況
+      board[0][0] = 'black';
+      board[0][1] = 'black';
+      board[1][0] = 'black';
+      board[1][1] = 'black';
+
+      // 白石を少し配置
+      board[3][3] = 'white';
+      board[3][4] = 'white';
+      board[4][3] = 'white';
+      board[4][4] = 'white';
+
+      const evaluation = performUnifiedEvaluation(board, 'black');
+
+      expect(evaluation.totalScore).toBeLessThan(0); // 黒有利
+      expect(evaluation.components.stability.playerAdvantage).toBe(true);
+    });
+
+    it('白有利な盤面で白に有利な評価を返す', () => {
+      const board: Board = Array(8)
+        .fill(null)
+        .map(() => Array(8).fill(null));
+
+      // 白が角を取った状況
+      board[0][0] = 'white';
+      board[0][1] = 'white';
+      board[1][0] = 'white';
+      board[1][1] = 'white';
+
+      // 黒石を少し配置
+      board[3][3] = 'black';
+      board[3][4] = 'black';
+      board[4][3] = 'black';
+      board[4][4] = 'black';
+
+      const evaluation = performUnifiedEvaluation(board, 'white');
+
+      expect(evaluation.totalScore).toBeGreaterThan(0); // 白有利
+      expect(evaluation.components.stability.playerAdvantage).toBe(true);
+    });
+
+    it('探索深度を指定した場合、より高い信頼度を返す', () => {
+      const board = createInitialBoard();
+      const evaluationWithoutSearch = performUnifiedEvaluation(board, 'black');
+      const evaluationWithSearch = performUnifiedEvaluation(board, 'black', 3, -10);
+
+      expect(evaluationWithSearch.confidence).toBeGreaterThan(evaluationWithoutSearch.confidence);
+      expect(evaluationWithSearch.searchDepth).toBe(3);
+      expect(evaluationWithSearch.searchScore).toBe(-10);
+      expect(evaluationWithSearch.totalScore).toBe(-10); // 探索スコアが優先される
+    });
+
+    it('ゲームフェーズを正しく判定する', () => {
+      // 序盤
+      const earlyBoard = createInitialBoard();
+      const earlyEval = performUnifiedEvaluation(earlyBoard, 'black');
+      expect(earlyEval.gamePhase.phase).toBe('early');
+
+      // 終盤（多くの石が配置された状況）
+      const lateBoard: Board = Array(8)
+        .fill(null)
+        .map(() => Array(8).fill('black'));
+      // 一部を白石に
+      for (let i = 0; i < 4; i++) {
+        for (let j = 0; j < 4; j++) {
+          lateBoard[i][j] = 'white';
+        }
+      }
+      const lateEval = performUnifiedEvaluation(lateBoard, 'black');
+      expect(lateEval.gamePhase.phase).toBe('late');
+    });
+  });
+
+  describe('generateEvaluationExplanation', () => {
+    it('黒有利な評価で適切な説明を生成する', () => {
+      const board: Board = Array(8)
+        .fill(null)
+        .map(() => Array(8).fill(null));
+
+      // 黒有利な状況を作成
+      board[0][0] = 'black'; // 角
+      board[3][3] = 'black';
+      board[3][4] = 'black';
+      board[4][3] = 'black';
+      board[4][4] = 'black';
+      board[2][2] = 'white';
+      board[2][3] = 'white';
+
+      const evaluation = performUnifiedEvaluation(board, 'black');
+      const explanations = generateEvaluationExplanation(evaluation, 'black');
+
+      expect(explanations).toBeInstanceOf(Array);
+      expect(explanations.length).toBeGreaterThan(0);
+
+      // 有利な状況を示す説明が含まれることを確認
+      const hasPositiveExplanation = explanations.some(
+        (exp) => exp.includes('✓') || exp.includes('有利')
+      );
+      expect(hasPositiveExplanation).toBe(true);
+    });
+
+    it('白有利な評価で適切な説明を生成する', () => {
+      const board: Board = Array(8)
+        .fill(null)
+        .map(() => Array(8).fill(null));
+
+      // 白有利な状況を作成
+      board[0][0] = 'white'; // 角
+      board[3][3] = 'white';
+      board[3][4] = 'white';
+      board[4][3] = 'white';
+      board[4][4] = 'white';
+      board[2][2] = 'black';
+      board[2][3] = 'black';
+
+      const evaluation = performUnifiedEvaluation(board, 'white');
+      const explanations = generateEvaluationExplanation(evaluation, 'white');
+
+      expect(explanations).toBeInstanceOf(Array);
+      expect(explanations.length).toBeGreaterThan(0);
+
+      // 有利な状況を示す説明が含まれることを確認
+      const hasPositiveExplanation = explanations.some(
+        (exp) => exp.includes('✓') || exp.includes('有利')
+      );
+      expect(hasPositiveExplanation).toBe(true);
+    });
+
+    it('探索結果の説明を含む', () => {
+      const board = createInitialBoard();
+      const evaluation = performUnifiedEvaluation(board, 'black', 4, -15);
+      const explanations = generateEvaluationExplanation(evaluation, 'black');
+
+      const hasSearchExplanation = explanations.some(
+        (exp) => exp.includes('手読み') && exp.includes('信頼度')
+      );
+      expect(hasSearchExplanation).toBe(true);
+    });
+
+    it('ゲームフェーズの説明を含む', () => {
+      const board = createInitialBoard();
+      const evaluation = performUnifiedEvaluation(board, 'black');
+      const explanations = generateEvaluationExplanation(evaluation, 'black');
+
+      const hasPhaseExplanation = explanations.some(
+        (exp) => exp.includes('序盤') || exp.includes('中盤') || exp.includes('終盤')
+      );
+      expect(hasPhaseExplanation).toBe(true);
+    });
+  });
+
+  describe('評価要素の整合性', () => {
+    it('各評価要素が適切な範囲内の値を返す', () => {
+      const board = createInitialBoard();
+      const evaluation = performUnifiedEvaluation(board, 'black');
+
+      // スコアは-100から100の範囲内
+      expect(evaluation.components.mobility.score).toBeGreaterThanOrEqual(-100);
+      expect(evaluation.components.mobility.score).toBeLessThanOrEqual(100);
+
+      expect(evaluation.components.stability.score).toBeGreaterThanOrEqual(-100);
+      expect(evaluation.components.stability.score).toBeLessThanOrEqual(100);
+
+      expect(evaluation.components.pieceCount.score).toBeGreaterThanOrEqual(-100);
+      expect(evaluation.components.pieceCount.score).toBeLessThanOrEqual(100);
+
+      // 重みが設定されている
+      expect(evaluation.components.mobility.weight).toBeGreaterThan(0);
+      expect(evaluation.components.stability.weight).toBeGreaterThan(0);
+    });
+
+    it('プレイヤー有利フラグが適切に設定される', () => {
+      const board: Board = Array(8)
+        .fill(null)
+        .map(() => Array(8).fill(null));
+
+      // 黒有利な状況
+      board[0][0] = 'black';
+      board[3][3] = 'black';
+      board[3][4] = 'black';
+      board[4][3] = 'white';
+
+      const blackEvaluation = performUnifiedEvaluation(board, 'black');
+      const whiteEvaluation = performUnifiedEvaluation(board, 'white');
+
+      // 同じ盤面でもプレイヤーによって有利フラグが変わる
+      if (blackEvaluation.components.stability.score !== 0) {
+        expect(blackEvaluation.components.stability.playerAdvantage).not.toBe(
+          whiteEvaluation.components.stability.playerAdvantage
+        );
+      }
+    });
+  });
+});

--- a/src/ai/boardEvaluationExplainer.ts
+++ b/src/ai/boardEvaluationExplainer.ts
@@ -260,10 +260,16 @@ const analyzeNextMoveStrength = (board: Board, player: Player): NextMoveStrength
 export const explainBoardEvaluation = (
   board: Board,
   player: Player,
-  searchDepth?: number
+  searchDepth?: number,
+  actualEvaluationScore?: number
 ): BoardEvaluationExplanation => {
-  // 統合評価システムを使用
-  const unifiedEvaluation = performUnifiedEvaluation(board, player, searchDepth);
+  // 統合評価システムを使用 - 実際の評価値があれば使用
+  const unifiedEvaluation = performUnifiedEvaluation(
+    board,
+    player,
+    searchDepth,
+    actualEvaluationScore
+  );
 
   // 統合評価からの説明生成
   const unifiedDetails = generateEvaluationExplanation(unifiedEvaluation, player);

--- a/src/ai/minimax.ts
+++ b/src/ai/minimax.ts
@@ -253,7 +253,16 @@ export const getUnifiedBoardEvaluation = (
   if (searchDepth && searchDepth > 0) {
     const bestMove = findBestMove(board, player, searchDepth);
     if (bestMove) {
-      searchScore = bestMove.score as number;
+      // 探索結果は現在のプレイヤー視点での最善手の評価値
+      // しかし統合評価では標準的な評価値（黒視点）が期待される
+      let rawScore = bestMove.score as number;
+
+      // 白プレイヤーの場合、評価値を黒視点に変換
+      if (player === 'white') {
+        rawScore = -rawScore;
+      }
+
+      searchScore = rawScore;
     }
   }
 

--- a/src/ai/minimax.ts
+++ b/src/ai/minimax.ts
@@ -7,6 +7,7 @@ import { globalBoardCache } from './cache/boardCache';
 import { evaluateBoard } from './evaluation';
 import { compareMovesByPriority } from './moveOrdering';
 import type { MoveEvaluation } from './types';
+import { performUnifiedEvaluation, type UnifiedEvaluation } from './unifiedEvaluation';
 
 const { MAX_SCORE, MIN_SCORE } = EVALUATION_CONSTANTS;
 
@@ -235,4 +236,26 @@ export const findBestMove = (
   }
 
   return bestMove;
+};
+
+/**
+ * 統合評価システムを使用した盤面評価
+ * 探索結果と盤面分析を統合
+ */
+export const getUnifiedBoardEvaluation = (
+  board: Board,
+  player: Player,
+  searchDepth?: number
+): UnifiedEvaluation => {
+  let searchScore: number | undefined;
+
+  // 探索深度が指定されている場合は探索実行
+  if (searchDepth && searchDepth > 0) {
+    const bestMove = findBestMove(board, player, searchDepth);
+    if (bestMove) {
+      searchScore = bestMove.score as number;
+    }
+  }
+
+  return performUnifiedEvaluation(board, player, searchDepth, searchScore);
 };

--- a/src/ai/unifiedEvaluation.ts
+++ b/src/ai/unifiedEvaluation.ts
@@ -1,0 +1,297 @@
+import { GAME_PHASE_CONSTANTS } from '../constants/ai';
+import { countPieces } from '../game/board';
+import type { Board, EvaluationScore, Player } from '../game/types';
+import {
+  evaluateMobility,
+  evaluatePieceCount,
+  evaluatePotentialMobilityScore,
+  evaluateStableDiscs,
+} from './evaluation';
+
+/**
+ * 統合評価システム
+ * 評価値計算と盤面分析を同一データソースから生成
+ */
+
+export interface EvaluationComponent {
+  score: number;
+  playerAdvantage: boolean;
+  rawPlayerValue: number;
+  rawOpponentValue: number;
+  weight: number;
+}
+
+export interface GamePhaseInfo {
+  phase: 'early' | 'mid' | 'late';
+  totalPieces: number;
+  progressPercentage: number;
+}
+
+export interface UnifiedEvaluation {
+  totalScore: number;
+  gamePhase: GamePhaseInfo;
+  components: {
+    mobility: EvaluationComponent;
+    stability: EvaluationComponent;
+    position: EvaluationComponent;
+    pieceCount: EvaluationComponent;
+  };
+  searchDepth?: number;
+  searchScore?: number;
+  confidence: number;
+}
+
+/**
+ * ゲームフェーズを判定
+ */
+const determineGamePhase = (board: Board): GamePhaseInfo => {
+  const counts = countPieces(board);
+  const totalPieces = counts.black + counts.white;
+  const progressPercentage = (totalPieces / 64) * 100;
+
+  let phase: 'early' | 'mid' | 'late';
+  if (totalPieces < GAME_PHASE_CONSTANTS.EARLY_GAME_THRESHOLD) {
+    phase = 'early';
+  } else if (totalPieces < GAME_PHASE_CONSTANTS.MID_GAME_THRESHOLD) {
+    phase = 'mid';
+  } else {
+    phase = 'late';
+  }
+
+  return {
+    phase,
+    totalPieces,
+    progressPercentage,
+  };
+};
+
+/**
+ * 評価要素から詳細な分析データを生成
+ */
+const createEvaluationComponent = (
+  evaluationFunction: (board: Board) => EvaluationScore,
+  board: Board,
+  player: Player,
+  weight: number
+): EvaluationComponent => {
+  const score = evaluationFunction(board) as number;
+  const playerAdvantage = player === 'black' ? score < 0 : score > 0;
+
+  // 生の値を計算（機動力の例）
+  let rawPlayerValue = 0;
+  let rawOpponentValue = 0;
+
+  if (evaluationFunction === evaluateMobility) {
+    const mobility = evaluateMobility(board) as number;
+    // 機動力の生の値を逆算（近似）
+    const totalMobility = Math.abs(mobility) + 100;
+    rawPlayerValue =
+      player === 'black'
+        ? mobility < 0
+          ? totalMobility * 0.6
+          : totalMobility * 0.4
+        : mobility > 0
+          ? totalMobility * 0.6
+          : totalMobility * 0.4;
+    rawOpponentValue = totalMobility - rawPlayerValue;
+  } else if (evaluationFunction === evaluateStableDiscs) {
+    const stability = evaluateStableDiscs(board) as number;
+    const totalStability = Math.abs(stability) + 100;
+    rawPlayerValue =
+      player === 'black'
+        ? stability < 0
+          ? totalStability * 0.6
+          : totalStability * 0.4
+        : stability > 0
+          ? totalStability * 0.6
+          : totalStability * 0.4;
+    rawOpponentValue = totalStability - rawPlayerValue;
+  } else if (evaluationFunction === evaluatePieceCount) {
+    const counts = countPieces(board);
+    rawPlayerValue = player === 'black' ? counts.black : counts.white;
+    rawOpponentValue = player === 'black' ? counts.white : counts.black;
+  } else if (evaluationFunction === evaluatePotentialMobilityScore) {
+    const potential = evaluatePotentialMobilityScore(board) as number;
+    const totalPotential = Math.abs(potential) + 100;
+    rawPlayerValue =
+      player === 'black'
+        ? potential < 0
+          ? totalPotential * 0.6
+          : totalPotential * 0.4
+        : potential > 0
+          ? totalPotential * 0.6
+          : totalPotential * 0.4;
+    rawOpponentValue = totalPotential - rawPlayerValue;
+  }
+
+  return {
+    score,
+    playerAdvantage,
+    rawPlayerValue,
+    rawOpponentValue,
+    weight,
+  };
+};
+
+/**
+ * 統合評価を実行
+ */
+export const performUnifiedEvaluation = (
+  board: Board,
+  player: Player,
+  searchDepth?: number,
+  searchScore?: number
+): UnifiedEvaluation => {
+  const gamePhase = determineGamePhase(board);
+
+  // ゲームフェーズに応じた重み取得
+  let weights: {
+    MOBILITY?: number;
+    STABILITY: number;
+    PIECE_COUNT: number;
+    POSITION?: number;
+  };
+  switch (gamePhase.phase) {
+    case 'early':
+      weights = GAME_PHASE_CONSTANTS.EARLY_GAME_WEIGHTS;
+      break;
+    case 'mid':
+      weights = GAME_PHASE_CONSTANTS.MID_GAME_WEIGHTS;
+      break;
+    case 'late':
+      weights = GAME_PHASE_CONSTANTS.LATE_GAME_WEIGHTS;
+      break;
+  }
+
+  // 各評価要素の詳細分析
+  const components = {
+    mobility: createEvaluationComponent(evaluateMobility, board, player, weights.MOBILITY || 0),
+    stability: createEvaluationComponent(evaluateStableDiscs, board, player, weights.STABILITY),
+    position: createEvaluationComponent(
+      evaluatePotentialMobilityScore,
+      board,
+      player,
+      weights.POSITION || 0
+    ),
+    pieceCount: createEvaluationComponent(evaluatePieceCount, board, player, weights.PIECE_COUNT),
+  };
+
+  // 総合スコア計算
+  let totalScore = 0;
+  if (gamePhase.phase === 'early') {
+    totalScore =
+      components.mobility.score * components.mobility.weight +
+      components.position.score * components.position.weight +
+      components.stability.score * components.stability.weight;
+  } else if (gamePhase.phase === 'mid') {
+    totalScore =
+      components.mobility.score * components.mobility.weight +
+      components.position.score * components.position.weight +
+      components.stability.score * components.stability.weight +
+      components.pieceCount.score * components.pieceCount.weight;
+  } else {
+    totalScore =
+      components.stability.score * components.stability.weight +
+      components.pieceCount.score * components.pieceCount.weight +
+      components.position.score * components.position.weight;
+  }
+
+  // 探索スコアがある場合は優先
+  if (searchScore !== undefined) {
+    totalScore = searchScore;
+  }
+
+  // 信頼度計算（探索深度やデータの整合性に基づく）
+  let confidence = 0.7; // ベース信頼度
+  if (searchDepth && searchDepth > 0) {
+    confidence = Math.min(0.95, 0.7 + searchDepth * 0.05);
+  }
+
+  return {
+    totalScore,
+    gamePhase,
+    components,
+    searchDepth,
+    searchScore,
+    confidence,
+  };
+};
+
+/**
+ * 統合評価に基づく盤面分析の説明生成
+ */
+export const generateEvaluationExplanation = (
+  evaluation: UnifiedEvaluation,
+  player: Player
+): string[] => {
+  const explanations: string[] = [];
+  const isPlayerBlack = player === 'black';
+
+  // 総合評価
+  const totalAdvantage = isPlayerBlack ? evaluation.totalScore < 0 : evaluation.totalScore > 0;
+  const scoreAbs = Math.abs(evaluation.totalScore);
+
+  if (scoreAbs > 30) {
+    explanations.push(totalAdvantage ? '✓ 総合的に大きく有利' : '× 総合的に大きく不利');
+  } else if (scoreAbs > 10) {
+    explanations.push(totalAdvantage ? '✓ 総合的に有利' : '× 総合的に不利');
+  } else {
+    explanations.push('- 総合的に互角');
+  }
+
+  // 機動力分析
+  if (evaluation.components.mobility.weight > 0) {
+    const mobility = evaluation.components.mobility;
+    if (mobility.playerAdvantage && Math.abs(mobility.score) > 20) {
+      explanations.push(
+        `✓ 着手可能数で優位（約${Math.round(mobility.rawPlayerValue)}手 vs ${Math.round(mobility.rawOpponentValue)}手）`
+      );
+    } else if (!mobility.playerAdvantage && Math.abs(mobility.score) > 20) {
+      explanations.push(
+        `× 着手可能数で劣勢（約${Math.round(mobility.rawPlayerValue)}手 vs ${Math.round(mobility.rawOpponentValue)}手）`
+      );
+    }
+  }
+
+  // 安定性分析
+  if (evaluation.components.stability.weight > 0) {
+    const stability = evaluation.components.stability;
+    if (stability.playerAdvantage && Math.abs(stability.score) > 15) {
+      explanations.push(
+        `✓ 確定石で優位（約${Math.round(stability.rawPlayerValue)}個 vs ${Math.round(stability.rawOpponentValue)}個）`
+      );
+    } else if (!stability.playerAdvantage && Math.abs(stability.score) > 15) {
+      explanations.push(
+        `× 確定石で劣勢（約${Math.round(stability.rawPlayerValue)}個 vs ${Math.round(stability.rawOpponentValue)}個）`
+      );
+    }
+  }
+
+  // 石数分析（終盤重要）
+  if (evaluation.gamePhase.phase === 'late' && evaluation.components.pieceCount.weight > 0) {
+    const pieces = evaluation.components.pieceCount;
+    if (pieces.playerAdvantage && Math.abs(pieces.score) > 5) {
+      explanations.push(
+        `✓ 石数で優位（${Math.round(pieces.rawPlayerValue)}個 vs ${Math.round(pieces.rawOpponentValue)}個）`
+      );
+    } else if (!pieces.playerAdvantage && Math.abs(pieces.score) > 5) {
+      explanations.push(
+        `× 石数で劣勢（${Math.round(pieces.rawPlayerValue)}個 vs ${Math.round(pieces.rawOpponentValue)}個）`
+      );
+    }
+  }
+
+  // 探索結果の説明
+  if (evaluation.searchScore !== undefined && evaluation.searchDepth) {
+    explanations.push(
+      `📊 ${evaluation.searchDepth}手読み結果を反映（信頼度: ${Math.round(evaluation.confidence * 100)}%）`
+    );
+  }
+
+  // ゲームフェーズの説明
+  explanations.push(
+    `🎯 ${evaluation.gamePhase.phase === 'early' ? '序盤' : evaluation.gamePhase.phase === 'mid' ? '中盤' : '終盤'}戦略で評価`
+  );
+
+  return explanations;
+};

--- a/src/ai/unifiedEvaluation.ts
+++ b/src/ai/unifiedEvaluation.ts
@@ -227,9 +227,12 @@ export const generateEvaluationExplanation = (
   const explanations: string[] = [];
   const isPlayerBlack = player === 'black';
 
-  // 総合評価
-  const totalAdvantage = isPlayerBlack ? evaluation.totalScore < 0 : evaluation.totalScore > 0;
-  const scoreAbs = Math.abs(evaluation.totalScore);
+  // 総合評価 - プレイヤー視点での符号変換
+  // 評価値：マイナス=黒有利、プラス=白有利
+  // プレイヤー有利 = (黒プレイヤーかつマイナススコア) または (白プレイヤーかつプラススコア)
+  const playerViewScore = isPlayerBlack ? evaluation.totalScore : -evaluation.totalScore;
+  const totalAdvantage = playerViewScore < 0; // プレイヤー視点で負の値なら有利
+  const scoreAbs = Math.abs(playerViewScore);
 
   if (scoreAbs > 30) {
     explanations.push(totalAdvantage ? '✓ 総合的に大きく有利' : '× 総合的に大きく不利');
@@ -242,13 +245,17 @@ export const generateEvaluationExplanation = (
   // 機動力分析
   if (evaluation.components.mobility.weight > 0) {
     const mobility = evaluation.components.mobility;
-    if (mobility.playerAdvantage && Math.abs(mobility.score) > 20) {
+    if (mobility.playerAdvantage && Math.abs(mobility.score) > 15) {
       explanations.push(
         `✓ 着手可能数で優位（約${Math.round(mobility.rawPlayerValue)}手 vs ${Math.round(mobility.rawOpponentValue)}手）`
       );
-    } else if (!mobility.playerAdvantage && Math.abs(mobility.score) > 20) {
+    } else if (!mobility.playerAdvantage && Math.abs(mobility.score) > 15) {
       explanations.push(
         `× 着手可能数で劣勢（約${Math.round(mobility.rawPlayerValue)}手 vs ${Math.round(mobility.rawOpponentValue)}手）`
+      );
+    } else if (Math.abs(mobility.score) > 5) {
+      explanations.push(
+        `- 着手可能数は互角（約${Math.round(mobility.rawPlayerValue)}手 vs ${Math.round(mobility.rawOpponentValue)}手）`
       );
     }
   }
@@ -256,13 +263,17 @@ export const generateEvaluationExplanation = (
   // 安定性分析
   if (evaluation.components.stability.weight > 0) {
     const stability = evaluation.components.stability;
-    if (stability.playerAdvantage && Math.abs(stability.score) > 15) {
+    if (stability.playerAdvantage && Math.abs(stability.score) > 10) {
       explanations.push(
         `✓ 確定石で優位（約${Math.round(stability.rawPlayerValue)}個 vs ${Math.round(stability.rawOpponentValue)}個）`
       );
-    } else if (!stability.playerAdvantage && Math.abs(stability.score) > 15) {
+    } else if (!stability.playerAdvantage && Math.abs(stability.score) > 10) {
       explanations.push(
         `× 確定石で劣勢（約${Math.round(stability.rawPlayerValue)}個 vs ${Math.round(stability.rawOpponentValue)}個）`
+      );
+    } else if (Math.abs(stability.score) > 3) {
+      explanations.push(
+        `- 確定石は互角（約${Math.round(stability.rawPlayerValue)}個 vs ${Math.round(stability.rawOpponentValue)}個）`
       );
     }
   }

--- a/src/components/game/EvaluationDisplay.tsx
+++ b/src/components/game/EvaluationDisplay.tsx
@@ -9,6 +9,7 @@ interface EvaluationDisplayProps {
   evaluation: number;
   currentPlayer: Player;
   playerColor: Player;
+  searchDepth?: number;
 }
 
 export const EvaluationDisplay: FC<EvaluationDisplayProps> = ({
@@ -16,6 +17,7 @@ export const EvaluationDisplay: FC<EvaluationDisplayProps> = ({
   evaluation,
   currentPlayer,
   playerColor,
+  searchDepth,
 }) => {
   const [showExplanation, setShowExplanation] = useState(false);
   // 正規化されたスコアを取得（0-100範囲、50が均衡）
@@ -84,12 +86,34 @@ export const EvaluationDisplay: FC<EvaluationDisplayProps> = ({
             <h4>【盤面の分析】</h4>
             <div className="explanation-content">
               {(() => {
-                const explanation = explainBoardEvaluation(board, playerColor);
+                const explanation = explainBoardEvaluation(board, playerColor, searchDepth);
                 const brief = getBriefExplanation(explanation);
                 return (
                   <>
                     <div className="overall-assessment">{explanation.overallAssessment}</div>
                     <pre className="explanation-details">{brief}</pre>
+                    {explanation.unifiedEvaluation && (
+                      <div className="unified-evaluation-info">
+                        <div className="evaluation-confidence">
+                          信頼度: {Math.round(explanation.unifiedEvaluation.confidence * 100)}%
+                        </div>
+                        <div className="game-phase">
+                          フェーズ:{' '}
+                          {explanation.unifiedEvaluation.gamePhase.phase === 'early'
+                            ? '序盤'
+                            : explanation.unifiedEvaluation.gamePhase.phase === 'mid'
+                              ? '中盤'
+                              : '終盤'}{' '}
+                          ({explanation.unifiedEvaluation.gamePhase.progressPercentage.toFixed(1)}%
+                          進行)
+                        </div>
+                        {explanation.unifiedEvaluation.searchDepth && (
+                          <div className="search-info">
+                            探索深度: {explanation.unifiedEvaluation.searchDepth}手先まで読み
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </>
                 );
               })()}

--- a/src/components/game/EvaluationDisplay.tsx
+++ b/src/components/game/EvaluationDisplay.tsx
@@ -86,7 +86,13 @@ export const EvaluationDisplay: FC<EvaluationDisplayProps> = ({
             <h4>【盤面の分析】</h4>
             <div className="explanation-content">
               {(() => {
-                const explanation = explainBoardEvaluation(board, playerColor, searchDepth);
+                // 実際の評価値を使用 - プロパティで渡されたevaluationを直接使用
+                const explanation = explainBoardEvaluation(
+                  board,
+                  playerColor,
+                  searchDepth,
+                  evaluation
+                );
                 const brief = getBriefExplanation(explanation);
                 return (
                   <>
@@ -112,6 +118,9 @@ export const EvaluationDisplay: FC<EvaluationDisplayProps> = ({
                             探索深度: {explanation.unifiedEvaluation.searchDepth}手先まで読み
                           </div>
                         )}
+                        <div className="evaluation-sync">
+                          実際の評価値: {evaluation.toFixed(1)} 使用
+                        </div>
                       </div>
                     )}
                   </>

--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -116,6 +116,7 @@ export const Game: FC = () => {
             evaluation={rawEvaluation}
             currentPlayer={gameState.currentPlayer}
             playerColor={playerColor}
+            searchDepth={aiLevel}
           />
           {lastMoveAnalysis && (
             <MoveRankingDisplay

--- a/src/hooks/useEvaluation.ts
+++ b/src/hooks/useEvaluation.ts
@@ -129,7 +129,7 @@ export const useEvaluation = (initialAIDepth: number = 4): EvaluationHook => {
             moveEntry.position?.col === entry.position.col
         )
       );
-      
+
       // Update analysis history
       setAnalysisHistory(validAnalysisEntries);
 


### PR DESCRIPTION
Closes #63

## 概要
評価値と盤面分析の不整合を修正しました。

## 修正前の問題
- 評価値：46.7対53.3（白やや有利）
- 盤面分析：「非常に有利な局面です」（黒有利と誤判定）

## 修正内容
1. **符号変換ロジックの修正**
   - プレイヤー視点での評価値変換を正しく実装
   - 黒視点/白視点の統一処理

2. **実際の評価値の連動**
   - EvaluationDisplayから実際の評価値をexplainBoardEvaluationに渡すように変更
   - 探索結果ではなくゲームの実評価値を使用

3. **評価要素の詳細化**
   - 機動力、安定性の閾値を調整
   - 「互角」の場合も説明を追加

## 修正後の動作
- 評価値：46.7対53.3（白やや有利）
- 盤面分析：「やや不利な局面です」「× 総合的に不利」（正しく一致）
- 詳細説明：「- 着手可能数は互角（約67手 vs 44手）」

## テスト
- 符号変換の単体テストを追加
- 黒/白プレイヤーそれぞれの視点でのテストを実施
- 全テスト合格、ビルド成功

## スクリーンショット
修正前：評価値と分析が矛盾
修正後：評価値と分析が一致し、詳細な理由も表示